### PR TITLE
Make Header Sticky

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -11,6 +11,7 @@ section {
 h1 {
     font-size: 130px;
     text-align: center;
+    margin-top: 25px;
     margin-bottom: 50px;
 }
 

--- a/css/main.css
+++ b/css/main.css
@@ -20,7 +20,7 @@ header {
     justify-content: space-between;
     align-items: center;
     background-color: #9c3587;
-    position: fixed;
+    position: sticky;
     top: 0;
     width: 100%;
     z-index: 100;
@@ -82,7 +82,6 @@ header .nav-btn .nav-btn-text {
 }
 
 main {
-    margin-top: 140px;
     background-color: #653780;
     color: #FBBEDE;
 }


### PR DESCRIPTION
The header element is made sticky such that the main element is positioned correctly without knowing the height of the header.
I also added some margin above the main heading.

Note that this does not fix the issue that navigating by clicking a hash anchor link does not jump (scroll) to the correct position on the page. Tricks like `padding-top: 140px; margin-top: -140px` will still need to be applied to fix the issue.